### PR TITLE
Fix docstring line length for Ruff compliance

### DIFF
--- a/src/vaxsim/simulation.py
+++ b/src/vaxsim/simulation.py
@@ -38,4 +38,3 @@ def simulate_trial(
         treatment_group.append(int(infected))
 
     return control_group, treatment_group
-

--- a/src/vaxsim/simulation.py
+++ b/src/vaxsim/simulation.py
@@ -1,1 +1,41 @@
 """Simulation module for vaccine trial outcomes."""
+
+import random
+
+
+def simulate_trial(
+    group_size: int,
+    exposure_rate: float,
+    baseline_risk: float,
+    vaccine_efficacy: float,
+) -> tuple[list[int], list[int]]:
+    """Simulate a randomized vaccine trial.
+
+    Args:
+        group_size (int): Number of individuals per group.
+        exposure_rate (float): Probability of exposure to the disease.
+        baseline_risk (float): Probability of infection if exposed and
+            unvaccinated.
+        vaccine_efficacy (float): Proportional reduction in infection risk.
+
+    Returns:
+        tuple[list[int], list[int]]: Infection outcomes for control and
+            treatment groups. 1 = infected, 0 = not infected.
+    """
+    control_group = []
+    treatment_group = []
+
+    for _ in range(group_size):
+        # Control group
+        exposed = random.random() < exposure_rate
+        infected = exposed and (random.random() < baseline_risk)
+        control_group.append(int(infected))
+
+        # Treatment group
+        exposed = random.random() < exposure_rate
+        adjusted_risk = baseline_risk * (1 - vaccine_efficacy)
+        infected = exposed and (random.random() < adjusted_risk)
+        treatment_group.append(int(infected))
+
+    return control_group, treatment_group
+


### PR DESCRIPTION
Implemented simulate_trial() function in simulation.py

Simulates infection outcomes for control and treatment groups based on:

group size

exposure rate

baseline infection risk

vaccine efficacy

Returns infection status (1 = infected, 0 = not infected) as two lists

Added docstrings and type hints

Reformatted code and fixed style issues to pass Ruff and mypy

